### PR TITLE
feat(ci): Move new_release_branch to Source Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Tag repositories with their respective next tag.
 
 - branches without any new commits since the last tag will not be re-tagged.
 - `master` branches are tagged with the next `{minor}` and `{patch}` of `0`.
-  For example, a repo with `master` tagged `1.2.0` will be tagged `1.3.0`.
+  For example, a repo with `master` tagged `v1.2.0` will be tagged `v1.3.0`.
 - all other branches (e.g: `release-*`) are tagged with the next `{patch}`.
-  For example, a repo with `release-1.27.x` tagged `1.2.3` will be tagged `1.2.4`.
+  For example, a repo with `release-1.27.x` tagged `v1.2.3` will be tagged `v1.2.4`.
 
 At time of writing, tagging designated (`master` and `release-*`) branches will:
 
@@ -142,19 +142,18 @@ TODO: Write a command to do this.
 
 ### Create Release Branches
 
+Create new `release-{major}-{minor}-x` branches off `master` at the most recent
+tag.
+
 Before starting this step all branches should be tagged with the latest semVer
-`{minor}` version and a `{patch}` value of `0`. For example: `1.2.0`
-
-TODO: Rewrite to branch off latest tag and not HEAD.
-
-Create new `release-{major}-{minor}-x` branches off HEAD on `master` branch.
+`{minor}` version and a `{patch}` value of `0`. For example: `v1.2.0`
 
 ```
 new_branch=release-1.27.x
 
 ./dev/buildtool.sh new_release_branch \
   --git_branch master \
-  --spinnaker_version "${new_branch}"
+  --new_branch "${new_branch}"
 ```
 
 When troubleshooting try using your forks, targeting a single service and
@@ -168,7 +167,7 @@ fork_owner=<you>
   --log_level debug \
   new_release_branch \
   --git_branch master \
-  --spinnaker_version "${new_branch}" \
+  --new_branch "${new_branch}" \
   --github_owner "${fork_owner}" \
   --only_repositories clouddriver \
   --git_never_push true

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ source .venv/bin/activate
 
 # install dependencies
 pip3 install pip --upgrade
-pip3 install -r dev/requirements.txt
-pip3 install -r dev/buildtool/requirements.txt
+pip3 install -r ./dev/requirements.txt
+pip3 install -r ./dev/buildtool/requirements.txt
+pip3 install -r ./testing/citest/requirements.txt
 
 # setup PYTHONPATH for IDE's and testing
 export PYTHONPATH="${PWD}/dev/"

--- a/dev/buildtool/git_support.py
+++ b/dev/buildtool/git_support.py
@@ -1160,7 +1160,12 @@ class GitRunner:
         logging.debug("Finished cloning %s", pull_url)
 
     def checkout(self, repository, commit):
+        """Checkout local repository at commit"""
         self.check_run(repository.git_dir, "checkout -q " + commit, echo=True)
+
+    def checkout_branch(self, git_dir, branch, start_point):
+        """Create branch at a specific start point"""
+        self.check_run(git_dir, f"checkout -q -b {branch} {start_point}", echo=True)
 
     def tag_commit(self, git_dir, tag, commit_id):
         """Add tag to the local repository at commit_id."""

--- a/dev/buildtool/git_support.py
+++ b/dev/buildtool/git_support.py
@@ -1163,7 +1163,7 @@ class GitRunner:
         """Checkout local repository at commit"""
         self.check_run(repository.git_dir, "checkout -q " + commit, echo=True)
 
-    def checkout_branch(self, git_dir, branch, start_point):
+    def create_branch(self, git_dir, branch, start_point):
         """Create branch at a specific start point"""
         self.check_run(git_dir, f"checkout -q -b {branch} {start_point}", echo=True)
 

--- a/dev/buildtool/source_commands.py
+++ b/dev/buildtool/source_commands.py
@@ -241,7 +241,7 @@ class NewReleaseBranchCommand(RepositoryCommandProcessor):
             tag,
             repository.origin,
         )
-        self.__git.checkout_branch(git_dir, branch, tag)
+        self.__git.create_branch(git_dir, branch, tag)
         self.__git.push_branch_to_origin(git_dir, branch)
 
 

--- a/dev/buildtool/source_commands.py
+++ b/dev/buildtool/source_commands.py
@@ -164,10 +164,10 @@ class NewReleaseBranchFactory(RepositoryCommandFactory):
         super().init_argparser(parser, defaults)
         self.add_argument(
             parser,
-            "release_branch_name",
+            "new_branch",
             defaults,
             None,
-            help='The release branch name should be "release-<num>.<num>.x"',
+            help='The new release branch name should be "release-<num>.<num>.x"',
         )
         self.add_argument(
             parser,
@@ -190,12 +190,12 @@ class NewReleaseBranchFactory(RepositoryCommandFactory):
 class NewReleaseBranchCommand(RepositoryCommandProcessor):
     def __init__(self, factory, options, **kwargs):
         super().__init__(factory, options, **kwargs)
-        check_options_set(options, ["release_branch_name"])
+        check_options_set(options, ["new_branch"])
         self.__git = GitRunner(options)
 
     def _do_repository(self, repository):
         git_dir = repository.git_dir
-        branch = self.options.release_branch_name
+        branch = self.options.new_branch
 
         logging.debug('Checking for branch="%s" in "%s"', branch, git_dir)
         remote_branches = [
@@ -235,7 +235,7 @@ class NewReleaseBranchCommand(RepositoryCommandProcessor):
         )
 
         logging.info(
-            'Creating "%s" off %s at "%s" and pushing to "%s"',
+            'Creating "%s" off "%s" at "%s" and pushing to "%s"',
             branch,
             self.options.git_branch,
             tag,

--- a/unittest/buildtool/source_commands_test.py
+++ b/unittest/buildtool/source_commands_test.py
@@ -52,7 +52,7 @@ class TestSourceCommandFixture(BaseGitRepoTestFixture):
             "only_repositories": NORMAL_SERVICE,
             "github_owner": "default",
             "git_branch": "master",  # tagged at HEAD
-            "release_branch_name": "release-0.1.x",
+            "new_branch": "release-0.1.x",
             "github_repository_root": self.options.github_repository_root,
         }
 
@@ -98,7 +98,7 @@ class TestSourceCommandFixture(BaseGitRepoTestFixture):
             "only_repositories": NORMAL_SERVICE,
             "github_owner": "default",
             "git_branch": PATCH_BRANCH,  # this branch has commits since last tag
-            "release_branch_name": "release-0.1.x",
+            "new_branch": "release-0.1.x",
             "github_repository_root": self.options.github_repository_root,
         }
 
@@ -145,7 +145,7 @@ class TestSourceCommandFixture(BaseGitRepoTestFixture):
             "only_repositories": NORMAL_SERVICE,
             "github_owner": "default",
             "git_branch": PATCH_BRANCH,  # this branch has commits since last tag
-            "release_branch_name": PATCH_BRANCH,  # same as source, i.e: already exists
+            "new_branch": PATCH_BRANCH,  # same as source, i.e: already exists
             "github_repository_root": self.options.github_repository_root,
         }
 

--- a/unittest/buildtool/spinnaker_commands_test.py
+++ b/unittest/buildtool/spinnaker_commands_test.py
@@ -34,45 +34,6 @@ class TestSpinnakerCommandFixture(BaseGitRepoTestFixture):
         self.parser = argparse.ArgumentParser()
         self.subparsers = self.parser.add_subparsers(title="command", dest="command")
 
-    def test_new_release_branch_command(self):
-        defaults = {
-            "input_dir": self.options.input_dir,
-            "output_dir": self.options.output_dir,
-            "only_repositories": EXTRA_REPO,
-            "github_owner": "default",
-            "git_branch": EXTRA_REPO + "-branch",
-            "spinnaker_version": "NewSpinnakerVersion",
-            "github_repository_root": self.options.github_repository_root,
-        }
-
-        registry = {}
-        bomtool_main.add_standard_parser_args(self.parser, defaults)
-        buildtool.spinnaker_commands.register_commands(
-            registry, self.subparsers, defaults
-        )
-
-        factory = registry["new_release_branch"]
-        factory.init_argparser(self.parser, defaults)
-
-        options = self.parser.parse_args(["new_release_branch"])
-
-        mock_push_tag = self.patch_method(GitRunner, "push_tag_to_origin")
-        mock_push_branch = self.patch_method(GitRunner, "push_branch_to_origin")
-
-        command = factory.make_command(options)
-        command()
-
-        base_git_dir = os.path.join(options.input_dir, "new_release_branch")
-        self.assertEqual(os.listdir(base_git_dir), [EXTRA_REPO])
-        git_dir = os.path.join(base_git_dir, EXTRA_REPO)
-        self.assertEqual(
-            GitRunner(options).query_local_repository_commit_id(git_dir),
-            self.repo_commit_map[EXTRA_REPO][EXTRA_REPO + "-branch"],
-        )
-
-        mock_push_branch.assert_called_once_with(git_dir, "NewSpinnakerVersion")
-        self.assertEqual(0, mock_push_tag.call_count)
-
 
 if __name__ == "__main__":
     init_runtime()


### PR DESCRIPTION
- This is where our other "source orchestrating" functionality lives.
- We only want to create new branches in some repo's, update in line
  with repo tagging.
- Fix up test and include some TODO's to be written.
